### PR TITLE
check laravel database config and grab redis driver

### DIFF
--- a/src/Mutex.php
+++ b/src/Mutex.php
@@ -25,6 +25,9 @@ class Mutex
         $this->ninja = new Ninja($command->getMutexName(), $this->strategy);
     }
 
+    /**
+     * @return FlockLock|MemcachedLock|MySqlLock|PhpRedisLock|PredisRedisLock
+     */
     public function getStrategy()
     {
         if (!empty($this->strategy)) {
@@ -79,6 +82,10 @@ class Mutex
         return call_user_func_array([$this->ninja, $method], $parameters);
     }
 
+    /**
+     * @param $driver
+     * @return PhpRedisLock|PredisRedisLock
+     */
     private function getRedisLock($driver)
     {
         switch ($driver) {


### PR DESCRIPTION
As it is possible to have the php-redis installed there is the need to distinguish which driver should be used. This is possible by reading the `database.redis.client` property from `conf/database.php`.

