### PR TITLE
fix Licence file name typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,6 @@ class ExampleCommand extends Command
 
 ## License
 
-The MIT License. Please see [License File](LICENSE) for more information.
+The MIT License. Please see [License File](LICENSE.md) for more information.
 
 [<img src="https://user-images.githubusercontent.com/1286821/43086829-ff7c006e-8ea6-11e8-8b03-ecf97ca95b2e.png" alt="Support on Patreon" width="125" />](https://patreon.com/dmitryivanov)


### PR DESCRIPTION
Simple typo fix.
It seems the Licence file name was recently changed, leaving README.md file outdated.

The issue occurs in master and 6.x branches.