### PR TITLE
New MySQLPDOLock class on NinjaMutex and MySQL driver with options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     }],
     "require": {
         "php": "^8.0.2",
-        "arvenil/ninja-mutex": "^0.6",
+        "arvenil/ninja-mutex": "dev-master#82cbb2c",
         "illuminate/console": "^9.0",
         "illuminate/support": "^9.0",
         "ramsey/collection": "^1.2"

--- a/src/Mutex.php
+++ b/src/Mutex.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Redis as RedisFacade;
 use NinjaMutex\Lock\FlockLock;
 use NinjaMutex\Lock\LockAbstract;
 use NinjaMutex\Lock\MemcachedLock;
-use NinjaMutex\Lock\MySqlLock;
+use NinjaMutex\Lock\MySQLPDOLock;
 use NinjaMutex\Lock\PhpRedisLock;
 use NinjaMutex\Lock\PredisRedisLock;
 use NinjaMutex\Mutex as NinjaMutex;
@@ -58,11 +58,14 @@ class Mutex
         $strategy = $this->command->getMutexStrategy();
         switch ($strategy) {
             case 'mysql':
-                return new MySqlLock(
+                return new MySQLPDOLock(
+                    'mysql:' . implode(';', [
+                        "host=" . config('database.connections.mysql.host'),
+                        "port=" . config('database.connections.mysql.port', 3306),
+                    ]),
                     config('database.connections.mysql.username'),
                     config('database.connections.mysql.password'),
-                    config('database.connections.mysql.host'),
-                    config('database.connections.mysql.port', 3306)
+                    config('database.connections.mysql.options')
                 );
 
             case 'redis':

--- a/src/Mutex.php
+++ b/src/Mutex.php
@@ -60,8 +60,8 @@ class Mutex
             case 'mysql':
                 return new MySQLPDOLock(
                     'mysql:' . implode(';', [
-                        "host=" . config('database.connections.mysql.host'),
-                        "port=" . config('database.connections.mysql.port', 3306),
+                        'host=' . config('database.connections.mysql.host'),
+                        'port=' . config('database.connections.mysql.port', 3306),
                     ]),
                     config('database.connections.mysql.username'),
                     config('database.connections.mysql.password'),

--- a/tests/MutexTest.php
+++ b/tests/MutexTest.php
@@ -67,8 +67,8 @@ class MutexTest extends TestCase
         $mutex = new Mutex($this->command);
         $expectedLock = new MySqlPdoLock(
             'mysql:' . implode(';', [
-                "host=" . config('database.connections.mysql.host'),
-                "port=" . config('database.connections.mysql.port', 3306),
+                'host=' . config('database.connections.mysql.host'),
+                'port=' . config('database.connections.mysql.port', 3306),
             ]),
             config('database.connections.mysql.username'),
             config('database.connections.mysql.password'),

--- a/tests/MutexTest.php
+++ b/tests/MutexTest.php
@@ -10,7 +10,7 @@ use Illuminated\Console\Tests\App\Console\Commands\GenericCommand;
 use Mockery\Mock;
 use NinjaMutex\Lock\FlockLock;
 use NinjaMutex\Lock\MemcachedLock;
-use NinjaMutex\Lock\MySqlLock;
+use NinjaMutex\Lock\MySQLPDOLock;
 use NinjaMutex\Lock\PhpRedisLock;
 use NinjaMutex\Lock\PredisRedisLock;
 use Predis\Client as PredisClient;
@@ -65,11 +65,14 @@ class MutexTest extends TestCase
         $this->command->expects('getMutexStrategy')->andReturn('mysql');
 
         $mutex = new Mutex($this->command);
-        $expectedLock = new MySqlLock(
+        $expectedLock = new MySqlPdoLock(
+            'mysql:' . implode(';', [
+                "host=" . config('database.connections.mysql.host'),
+                "port=" . config('database.connections.mysql.port', 3306),
+            ]),
             config('database.connections.mysql.username'),
             config('database.connections.mysql.password'),
-            config('database.connections.mysql.host'),
-            config('database.connections.mysql.port', 3306)
+            config('database.connections.mysql.options')
         );
         $this->assertEquals($expectedLock, $mutex->getNinjaMutexLock());
     }


### PR DESCRIPTION
This PR allows to use the mysql strategy and set options with the PDO driver.

It was motivated by the need of connecting to a MySQL/MariaDB server with the SSL/TLS option required. If that option is rightly configured in your Laravel's database config this patch uses the *database.connections.mysql.options* setup transparently.

_NinjaMutex_ master branch is required to pass the options parameter. Last release of [arvenil/mutex](https://github.com/arvenil/mutex) at this PR moment is 0.6 so that composer dependency is dev-master#82cbb2c (Feb 1, 2021). If a new release of NinjaMutex is published [it should be set on this composer.json](https://github.com/rafacouto/laravel-console-mutex/blob/feature/NinjaMutex-MySQLPDOLock/composer.json#L16).